### PR TITLE
Transfer from Google Sheets to "Anlage zur Reisekostenabrechnung" was omiting first row

### DIFF
--- a/public/forms/reisekostenabrechnung-anlage.yaml
+++ b/public/forms/reisekostenabrechnung-anlage.yaml
@@ -4,7 +4,7 @@ sheet: 1Ox5TYBfDbY_4eRKcHxlehIsAgOZoLP0M4PYjTF4mymU
 
 tables:
   entries:
-    sheetDataStartsAtRow: 1
+    sheetDataStartsAtRow: 2
     lines: 24
     height: 5.68
     startXY: [13, 58]

--- a/public/forms/reisekostenabrechnung-anlage.yaml
+++ b/public/forms/reisekostenabrechnung-anlage.yaml
@@ -4,7 +4,7 @@ sheet: 1Ox5TYBfDbY_4eRKcHxlehIsAgOZoLP0M4PYjTF4mymU
 
 tables:
   entries:
-    sheetDataStartsAtRow: 2
+    sheetDataStartsAtRow: 1
     lines: 24
     height: 5.68
     startXY: [13, 58]

--- a/src/components/Sheetsulator.vue
+++ b/src/components/Sheetsulator.vue
@@ -116,7 +116,7 @@ export default {
     async loadSheet() {
       const rootURL = this.sheetURL.slice(0, this.sheetURL.lastIndexOf('/'))
       // just
-      const csvURL = rootURL + '/gviz/tq?tqx=out:csv&range=A2:J27'
+      const csvURL = rootURL + '/gviz/tq?tqx=out:csv&range=A'+ this.formConfig.tables.entries.sheetDataStartsAtRow + ':J27'
       const raw = await (await fetch(csvURL)).text()
 
       if (raw.startsWith('<!DOCTYPE')) {
@@ -139,7 +139,7 @@ export default {
 
       this.entries = []
       for (let i = 0; i < entryConfig.lines; i++) {
-        const row = csv[i + (entryConfig.sheetDataStartsAtRow - 1)] as any[]
+        const row = csv[i] as any[]
 
         // hard-code exceptions for now
         if (!row) break


### PR DESCRIPTION
Problem: first row from google sheets was not showing up on the "Anlage zur Reisekostenabrechnung". In the first screenshot, you see that the first row of the google sheets is "Zugang Berlin Hbf": 
![image](https://github.com/user-attachments/assets/7c89c2d8-88cc-4d45-923a-ce45b763ae6a)

In the next screenshot you see that it this row doesn't show up in the PDF:
![image](https://github.com/user-attachments/assets/50514759-a4a8-4b5a-bdb6-5382f9f4c942)

In this PR, I just configuration in the reisekostenabrechnung-anlage.yaml, telling the API that the relevant data starts at row1 of the google sheet, and not row2. 

